### PR TITLE
Dropbox Third Party Picker/URL Handling

### DIFF
--- a/juxtapose/js/juxtapose.js
+++ b/juxtapose/js/juxtapose.js
@@ -434,6 +434,7 @@
       this.setWrapperDimensions();
       return result;
     },
+
     _onLoaded: function() {
 
       if (this.imgBefore && this.imgBefore.loaded === true &&

--- a/website/app.py
+++ b/website/app.py
@@ -30,6 +30,7 @@ settings = sys.modules[settings_module]
 build_dir = os.path.join(settings.JUXTAPOSE_ROOT, 'build')
 source_dir = os.path.join(settings.JUXTAPOSE_ROOT, 'juxtapose')
 
+
 @app.context_processor
 def inject_urls():
     """
@@ -43,6 +44,7 @@ def inject_urls():
     storage_url = settings.AWS_STORAGE_BUCKET_URL
     if not storage_url.endswith('/'):
         storage_url += '/'
+
     storage_url += settings.AWS_STORAGE_BUCKET_KEY
     if not storage_url.endswith('/'):
         storage_url += '/'
@@ -51,11 +53,13 @@ def inject_urls():
     if not cdn_url.endswith('/'):
         cdn_url += '/'
 
+    dropbox_app_key = settings.DROPBOX_APP_KEY
+
     return dict(
         STATIC_URL=static_url, static_url=static_url,
         STORAGE_URL=storage_url, storage_url=storage_url,
-        CDN_URL=cdn_url, cdn_url=cdn_url)
-
+        CDN_URL=cdn_url, cdn_url=cdn_url,
+        DROPBOX_APP_KEY=dropbox_app_key, dropbox_app_key=dropbox_app_key)
 
 
 @app.route('/')
@@ -76,7 +80,6 @@ def catch_source(path):
     Serve /source/... urls from the source directory
     """
     return send_from_directory(source_dir, path)
-
 
 
 # Juxtapose API
@@ -105,14 +108,13 @@ def upload_juxtapose_json():
         traceback.print_exc()
         return jsonify({'error': str(e)})
 
-    
-        
+
 if __name__ == "__main__":
     import getopt
-    
+
     ssl_context = None
     port = 5000
-    
+
     try:
         opts, args = getopt.getopt(sys.argv[1:], "sp:", ["port="])
         for opt, arg in opts:
@@ -122,9 +124,9 @@ if __name__ == "__main__":
                 port = int(arg)
             else:
                 print 'Usage: app.py [-s]'
-                sys.exit(1)   
+                sys.exit(1)
     except getopt.GetoptError:
         print 'Usage: app.py [-s] [-p port]'
         sys.exit(1)
-       
+
     app.run(host='0.0.0.0', port=5000, debug=True, ssl_context=ssl_context)

--- a/website/core/settings/loc.py
+++ b/website/core/settings/loc.py
@@ -13,7 +13,7 @@ from secrets import *
 
 # Set Flask configuration
 os.environ['FLASK_CONFIG_MODULE'] = os.path.join(secrets_path, 'flask_config.py')
-    
+
 STATIC_URL = '/static/'
 
 # CDN_URL = 'https://s3.amazonaws.com/cdn.knightlab.com/libs/juxtapose/dev/'

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -258,6 +258,24 @@ span.tip-plus {
   max-width: none !important;
 }
 
+/* FORMS */
+.input-group input {
+  width: calc(100% - 3em - 12px - 1px - 1em);
+}
+.input-group .buttons {
+  display: inline-block;
+  float: right;
+}
+.input-group:after {
+  content: '';
+  display: block;
+  float: none;
+  clear: both;
+}
+.input-group button {
+  width: 3em;
+}
+
 /* preview */
 h6 {
   text-transform: none;

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -276,11 +276,14 @@ span.tip-plus {
   width: 3em;
 }
 
+.warning {
+  font-size: .875em;
+}
+
 /* preview */
 h6 {
   text-transform: none;
 }
-#slider-size-warning { display: none; }
 #embed-code {
   height: 100px;
 }
@@ -296,4 +299,12 @@ h6 {
 #publish-error {
   display: none;
   margin: 10px 0;
+}
+
+#slider-preview-warning {
+  margin-top: 1em;
+}
+.preview-row {
+  margin-top: 1.5em;
+  margin-bottom: 3em;
 }

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -185,3 +185,70 @@ function handleDropboxLink(files, image) {
     }
     createSliderFromForm();
 }
+
+// GOOGLE CHROME
+
+// The Browser API key obtained from the Google Developers Console.
+var developerKey = 'xxxxxxxYYYYYYYY-12345678';
+
+// The Client ID obtained from the Google Developers Console. Replace with your own Client ID.
+var clientId = "1234567890-abcdefghijklmnopqrstuvwxyz.apps.googleusercontent.com"
+
+// Scope to use to access user's photos.
+var scope = ['https://www.googleapis.com/auth/photos'];
+
+var pickerApiLoaded = false;
+var oauthToken;
+
+// Use the API Loader script to load google.picker and gapi.auth.
+function onApiLoad() {
+    gapi.load('auth', {'callback': onAuthApiLoad});
+    gapi.load('picker', {'callback': onPickerApiLoad});
+}
+
+function onAuthApiLoad() {
+window.gapi.auth.authorize(
+    {
+      'client_id': clientId,
+      'scope': scope,
+      'immediate': false
+    },
+    handleAuthResult);
+}
+
+function onPickerApiLoad() {
+    pickerApiLoaded = true;
+    createPicker();
+}
+
+function handleAuthResult(authResult) {
+    if (authResult && !authResult.error) {
+        oauthToken = authResult.access_token;
+        createPicker();
+    }
+}
+
+// Create and render a Picker object for picking user Photos.
+function createPicker() {
+if (pickerApiLoaded && oauthToken) {
+    var picker = new google.picker.PickerBuilder().
+        addView(google.picker.ViewId.PHOTOS).
+        setOAuthToken(oauthToken).
+        setDeveloperKey(developerKey).
+        setCallback(pickerCallback).
+        build();
+        picker.setVisible(true);
+    }
+}
+
+// A simple callback implementation.
+function pickerCallback(data) {
+var url = 'nothing';
+if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
+  var doc = data[google.picker.Response.DOCUMENTS][0];
+  url = doc[google.picker.Document.URL];
+}
+var message = 'You picked: ' + url;
+document.getElementById('result').innerHTML = message;
+}
+

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -49,9 +49,8 @@ function createSliderFromForm() {
       if (result == juxtapose.OPTIMIZATION_WAS_CONSTRAINED){
         document.getElementById('slider-size-warning').style.display = 'block';
       }
-    }
+    };
     window.slider_preview = new juxtapose.JXSlider("#create-slider-preview", imageDataFromForm(), opts);
-    updateEmbedCode();
 }
 
 $("#update-preview").click(createSliderFromForm);
@@ -68,31 +67,6 @@ function imageTagForObject(o) {
 function updateEmbedCode() {
     var imgs = imageDataFromForm();
     var opts = optionsFromForm();
-    /*
-            animate: w.getAttribute('data-animate'),
-            showLabels: w.getAttribute('data-showlabels'),
-            showCredits: w.getAttribute('data-showcredits'),
-            startingPosition: w.getAttribute('data-startingposition')
-
-    */
-    // code =  '<div class="juxtapose" data-startingposition="'
-    //             + opts.startingPosition
-    //             + '" data-showlabels="'
-    //             + opts.showLabels
-    //             + '" data-showcredits="'
-    //             + opts.showCredits
-    //             +'" data-animate="'
-    //             + opts.animate
-    //             +'" data-mode="'
-    //             + opts.mode
-    //             +'">\n'
-    //             + imageTagForObject(imgs[0])
-    //             + '\n'
-    //             + imageTagForObject(imgs[1])
-    //             +'\n'
-    //         + '</div>'
-
-    // $('#embed-code').text(code);
 }
 
 $('a.help').popover({
@@ -112,7 +86,7 @@ $(document).click(function(e) {
 
 $("#authoring-form input.auto-update").change(function(evt) {
     createSliderFromForm();
-})
+});
 
 $("#authoring-form input#starting-position").change(function(evt) {
     try {
@@ -125,19 +99,17 @@ $("#authoring-form input#starting-position").change(function(evt) {
     } catch(e) {
         evt.preventDefault();
     }
-})
+});
 
 $("#use-current-position").click(function(){
     var pos = slider_preview.getPosition();
     pos = pos.replace('%','').split('.')[0];
     $("#starting-position").val(pos);
-    updateEmbedCode();
 });
 
 createSliderFromForm();
 
 var iFrameURL = 'https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html';
-
 function createIFrameCode(data) {
     var uid = data.uid;
     var url = iFrameURL + '?uid=' + uid;
@@ -154,7 +126,7 @@ function getJSONToPublish() {
     data = {
         'images': imageDataFromForm(),
         'options': optionsFromForm(),
-    }
+    };
     return data;
 }
 
@@ -190,4 +162,26 @@ function publishSlider() {
 $("#publish-slider").click(publishSlider);
 
 
+// THIRD PARTY CHOOSERS
+$('.dropbox-picker').click(function(e) {
+    alert("PICKERD");
+    e.preventDefault();
 
+    var image = $(this).data('image');
+    Dropbox.choose({
+        success: function(files) { handleDropboxLink(files, image); },
+        linkType: "preview", 
+        extensions: ['images']
+    });
+});
+
+function handleDropboxLink(files, image) {
+    var file = files[0];
+    var url = file.link.replace("www.dropbox.com", "dl.dropbox.com");
+    if (image == 'before') {
+        $("#before-src").val(url);
+    } else if (image == 'after') {
+        $("#after-src").val(url);
+    }
+    createSliderFromForm();
+}

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -1,12 +1,12 @@
 function imageDataFromForm() {
     return [
         {
-            src: $("#before-src").val(),
+            src: processThirdPartyLinks($("#before-src").val()),
             label: $("#before-label").val(),
             credit: $("#before-credit").val()
         },
         {
-            src: $("#after-src").val(),
+            src: processThirdPartyLinks($("#after-src").val()),
             label: $("#after-label").val(),
             credit: $("#after-credit").val()
         }
@@ -162,92 +162,41 @@ function publishSlider() {
 $("#publish-slider").click(publishSlider);
 
 
-// THIRD PARTY CHOOSERS
+// THIRD PARTY PICKERS
+
+function processThirdPartyLinks(url) {
+    if (url.indexOf("www.dropbox.com") > 0) {
+        return handleDropboxLink(url);
+    }
+    // HANDLE 
+    return url
+}
+
 $('.dropbox-picker').click(function(e) {
     e.preventDefault();
 
     var image = $(this).data('image');
     Dropbox.choose({
-        success: function(files) { handleDropboxLink(files, image); },
+        success: function(files) { handleDropboxPickerLink(files, image); },
         linkType: "preview", 
         extensions: ['images']
     });
 });
 
-function handleDropboxLink(files, image) {
-    var file = files[0];
-    var url = file.link.replace("www.dropbox.com", "dl.dropbox.com");
+function handleDropboxLink(url) {
+    if (url.indexOf("?") > 0) {
+        url = url.split("?")[0]
+    }
+    url += "?raw=1"
+    return url;
+}
+
+function handleDropboxPickerLink(files, image) {
     if (image == 'before') {
-        $("#before-src").val(url);
+        $("#before-src").val(files[0].link);
     } else if (image == 'after') {
-        $("#after-src").val(url);
+        $("#after-src").val(files[0].link);
     }
     createSliderFromForm();
-}
-
-// GOOGLE CHROME
-
-// The Browser API key obtained from the Google Developers Console.
-var developerKey = 'xxxxxxxYYYYYYYY-12345678';
-
-// The Client ID obtained from the Google Developers Console. Replace with your own Client ID.
-var clientId = "1234567890-abcdefghijklmnopqrstuvwxyz.apps.googleusercontent.com"
-
-// Scope to use to access user's photos.
-var scope = ['https://www.googleapis.com/auth/photos'];
-
-var pickerApiLoaded = false;
-var oauthToken;
-
-// Use the API Loader script to load google.picker and gapi.auth.
-function onApiLoad() {
-    gapi.load('auth', {'callback': onAuthApiLoad});
-    gapi.load('picker', {'callback': onPickerApiLoad});
-}
-
-function onAuthApiLoad() {
-window.gapi.auth.authorize(
-    {
-      'client_id': clientId,
-      'scope': scope,
-      'immediate': false
-    },
-    handleAuthResult);
-}
-
-function onPickerApiLoad() {
-    pickerApiLoaded = true;
-    createPicker();
-}
-
-function handleAuthResult(authResult) {
-    if (authResult && !authResult.error) {
-        oauthToken = authResult.access_token;
-        createPicker();
-    }
-}
-
-// Create and render a Picker object for picking user Photos.
-function createPicker() {
-if (pickerApiLoaded && oauthToken) {
-    var picker = new google.picker.PickerBuilder().
-        addView(google.picker.ViewId.PHOTOS).
-        setOAuthToken(oauthToken).
-        setDeveloperKey(developerKey).
-        setCallback(pickerCallback).
-        build();
-        picker.setVisible(true);
-    }
-}
-
-// A simple callback implementation.
-function pickerCallback(data) {
-var url = 'nothing';
-if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
-  var doc = data[google.picker.Response.DOCUMENTS][0];
-  url = doc[google.picker.Document.URL];
-}
-var message = 'You picked: ' + url;
-document.getElementById('result').innerHTML = message;
 }
 

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -164,7 +164,6 @@ $("#publish-slider").click(publishSlider);
 
 // THIRD PARTY CHOOSERS
 $('.dropbox-picker').click(function(e) {
-    alert("PICKERD");
     e.preventDefault();
 
     var image = $(this).data('image');

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -192,7 +192,7 @@ $('.dropbox-picker').click(function(e) {
 function handleDropboxLink(url, pos) {
     // Warn if /home and not share link
     if (url.indexOf("home") > 0) { 
-        createWarning($("#" + pos).parent(), "<strong>Not An Image Link:</strong> It looks like you copied the wrong link from Dropbox. Try using the image's <a href='https://www.dropbox.com/help/167'>share url</a>.")
+        createWarning($("#" + pos).parent(), "<strong>Not An Image Link:</strong> It looks like you copied the wrong link from Dropbox. Try using the image's <a href='https://www.dropbox.com/help/167' target='_blank'>share url</a>.")
     }
 
     if (url.indexOf("?") > 0) {

--- a/website/templates/_create.html
+++ b/website/templates/_create.html
@@ -7,25 +7,36 @@
   <div class="container-fluid">
     <form id="authoring-form">
       <div class="row-fluid">
-        <div class="span6">
+        <div class="span8">
           <div class="imgBefore row-fluid">
-            <h6>Left image</h6>
-            <input type="url" id="before-src" class="urlBox span11 auto-update" placeholder="https://example.com/firstimage.jpg" value="https://juxtapose.knightlab.com/static/img/Sochi_11April2005.jpg">
-            <input type="text" id="before-label" value="Apr. 2005" class="span3 auto-update" placeholder="Label (optional)">
-            <input type="text" id="before-credit" class="span8 auto-update" placeholder="Credit (optional)">
-            <button class="dropbox-picker" data-image='before'>Dropbox</button>
+            <div class="span11">
+              <h6>Left image</h6>
+              <div class="input-group">
+                <input type="url" id="before-src" class="urlBox auto-update" placeholder="https://example.com/firstimage.jpg" value="https://juxtapose.knightlab.com/static/img/Sochi_11April2005.jpg">
+                <div class="buttons">
+                  <button class="btn btn-default dropbox-picker" data-image="before" type="button"><i class="icon-large icon-dropbox" aria-hidden="true"></i></button>
+                </div>
+              </div>
+              <input type="text" id="before-label" value="Apr. 2005" class="span4 auto-update" placeholder="Label (optional)">
+              <input type="text" id="before-credit" class="span8 auto-update" placeholder="Credit (optional)">
+            </div>
           </div>
-
           <div class="imgAfter row-fluid">
+            <div class="span11">
               <h6>Right image</h6>
-              <input type="url" id="after-src" class="urlBox span11 auto-update" placeholder="https://example.com/secondimage.jpg" value="https://juxtapose.knightlab.com/static/img/Sochi_22Nov2013.jpg">
-              <input type="text" id="after-label" value="Nov. 2013" class="span3 auto-update" placeholder="Label (optional)">
+              <div class="input-group">
+                  <input type="url" id="after-src" class="urlBox auto-update" placeholder="https://example.com/secondimage.jpg" value="https://juxtapose.knightlab.com/static/img/Sochi_22Nov2013.jpg">
+                  <div class="buttons">
+                    <button class="btn btn-default dropbox-picker" data-image="after" type="button"><i class="icon-large icon-dropbox" aria-hidden="true"></i></button>
+                  </div>
+              </div>
+              <input type="text" id="after-label" value="Nov. 2013" class="span4 auto-update" placeholder="Label (optional)">
               <input type="text" id="after-credit" class="span8 auto-update" placeholder="Credit (optional)">
-              <button class="dropbox-picker" data-image='after'>Dropbox</button>
+            </div>
           </div>
           <p class="tip"><span class="tip-plus">+</span>If you don't have a web server for your images, you can host them on Flickr, Dropbox, or Google Drive.</p>
         </div>
-        <div class="span6">
+        <div class="span4">
           <div class="row-fluid">
             <div class="span12">
               <h6>Slider start position</h6>

--- a/website/templates/_create.html
+++ b/website/templates/_create.html
@@ -66,15 +66,16 @@
       </div>
     </div>
   </div>
-  <div class="row-fluid">
+
+  <div class="row-fluid preview-row">
      <div class="span12">
       <h4>Preview</h4>
-      <div class="alert alert-warning" id="slider-size-warning">Note: One or both of your photos is larger than your browser window. The preview below has been resized to fit your screen, but your embedded Juxtapose will retain your original image dimensions.</div>
-      <div id="preview-container" style="width: 100%;">
-        <div id="create-slider-preview">
-        <img src="//online.wsj.com/media/LIONDOOR_2A.jpg" height="500 ">
+        <div id="preview-container" style="width: 100%;">
+          <div id="create-slider-preview">
+          <img src="//online.wsj.com/media/LIONDOOR_2A.jpg" height="500 ">
+          </div>
         </div>
-      </div>
+        <div id="slider-preview-warning" class="span6"></div>
     </div>
   </div>
 

--- a/website/templates/_create.html
+++ b/website/templates/_create.html
@@ -13,6 +13,7 @@
             <input type="url" id="before-src" class="urlBox span11 auto-update" placeholder="https://example.com/firstimage.jpg" value="https://juxtapose.knightlab.com/static/img/Sochi_11April2005.jpg">
             <input type="text" id="before-label" value="Apr. 2005" class="span3 auto-update" placeholder="Label (optional)">
             <input type="text" id="before-credit" class="span8 auto-update" placeholder="Credit (optional)">
+            <button class="dropbox-picker" data-image='before'>Dropbox</button>
           </div>
 
           <div class="imgAfter row-fluid">
@@ -20,6 +21,7 @@
               <input type="url" id="after-src" class="urlBox span11 auto-update" placeholder="https://example.com/secondimage.jpg" value="https://juxtapose.knightlab.com/static/img/Sochi_22Nov2013.jpg">
               <input type="text" id="after-label" value="Nov. 2013" class="span3 auto-update" placeholder="Label (optional)">
               <input type="text" id="after-credit" class="span8 auto-update" placeholder="Credit (optional)">
+              <button class="dropbox-picker" data-image='after'>Dropbox</button>
           </div>
           <p class="tip"><span class="tip-plus">+</span>If you don't have a web server for your images, you can host them on Flickr, Dropbox, or Google Drive.</p>
         </div>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -22,6 +22,10 @@
   <script src="{{ STATIC_URL }}js/html5shiv.js"></script>
   <![endif]-->
 
+  <!-- Third Party Choosers -->
+  <script type="text/javascript" src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="{{ DROPBOX_APP_KEY }}"></script>
+
+
   {# Google Analytics: don't mess with this stuff #}
   {# named tracker notes from https://developers.google.com/analytics/devguides/collection/gajs/ #}
   {# multi-domain tracking notes from https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingSite #}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -24,6 +24,7 @@
 
   <!-- Third Party Choosers -->
   <script type="text/javascript" src="https://www.dropbox.com/static/api/2/dropins.js" id="dropboxjs" data-app-key="{{ DROPBOX_APP_KEY }}"></script>
+  <script type="text/javascript" src="https://apis.google.com/js/api.js?onload=onApiLoad"></script>
 
 
   {# Google Analytics: don't mess with this stuff #}


### PR DESCRIPTION
One little smell that probably needs to be dealt with is that right now, `handleDropboxPickerLink` changes the value of the input box before `processThirdPartyLinks` is called. This means that the value displayed in the input box is not the same as the value that is ultimately used (i.e., it doesn't include the `?raw=1` query). *Is that a place where we need to be more transparent to the user about what's happening behind the scenes?*

Here's what the new authoring field looks like. Would love a few design tweaks here. *How finicky do we want to be fighting against Blueline? Or should we start trying to move to Purpleline?*

<img width="779" alt="screen shot 2016-04-25 at 3 08 46 pm" src="https://cloud.githubusercontent.com/assets/2475973/14797416/57e6c8e0-0af8-11e6-8cdd-9ff0ad480534.png">

Also some todos before merging:

- [x] Create a Dropbox Juxtapose App and add the `DROPBOX_APP_KEY` to the secrets repository (@joegermuska)
- [ ] Design review on the new buttons (maybe a user test or two)

This will fix #67 when merged.