### PR TITLE
Fix for vertical sliders in Firefox

### DIFF
--- a/juxtapose/js/juxtapose.js
+++ b/juxtapose/js/juxtapose.js
@@ -221,7 +221,7 @@
     } else {
       var sliderRect = slider.getBoundingClientRect();
       var offset = {
-        top: sliderRect.top + document.body.scrollTop,
+        top: sliderRect.top + (document.documentElement || document.body.parentNode || document.body).scrollTop,
         left: sliderRect.left + document.body.scrollLeft
       };
       var width = slider.offsetHeight;


### PR DESCRIPTION
Different browsers use different implementations: document.body vs. document.documentElement.
In Firefox document.body is null so document.body.scrollTop is always zero, regardless of where the slider is placed in the page.
(I suppose it should be done to scrollLeft also, but it's very rare that the page has to be scrolled horizontally to access a slider — even more so in a responsive environment. But if I test the demo with the window narrowed so that I can scroll horizontally, the horizontal slider too has problems...)