### PR TITLE
Fix slider in vertical mode in IE and Firefox

### DIFF
--- a/juxtapose/css/juxtapose.css
+++ b/juxtapose/css/juxtapose.css
@@ -123,7 +123,7 @@ div.jx-arrow.jx-right {
 
 .vertical div.jx-arrow.jx-right {
 	right: 0px;
-	top: initial;
+	top: auto;
 	bottom: 2px;
 	border-style: solid;
 	border-width: 8px 8px 0 8px;
@@ -165,7 +165,7 @@ div.jx-image {
 .vertical div.jx-image {
 	width: 100%;
 	left: 0;
-	top: initial;
+	top: auto;
 }
 
 div.jx-image img {
@@ -180,7 +180,7 @@ div.jx-image img {
 }
 
 .vertical div.jx-image img {
-	height: initial;
+	height: auto;
 	width: 100%;
 }
 
@@ -256,7 +256,7 @@ div.jx-image.jx-right div.jx-label {
 .vertical div.jx-image.jx-right div.jx-label {
 	left: 0;
 	bottom: 0;
-	top: initial;
+	top: auto;
 }
 
 div.jx-credit {

--- a/juxtapose/js/juxtapose.js
+++ b/juxtapose/js/juxtapose.js
@@ -204,8 +204,8 @@
     } else {
       var sliderRect = slider.getBoundingClientRect();
       var offset = {
-        top: sliderRect.top + document.body.scrollTop,
-        left: sliderRect.left + document.body.scrollLeft
+        top: sliderRect.top + document.body.scrollTop + document.documentElement.scrollTop,
+        left: sliderRect.left + document.body.scrollLeft + document.documentElement.scrollLeft
       };
       var width = slider.offsetWidth;
       var pageX = getPageX(input);
@@ -221,8 +221,8 @@
     } else {
       var sliderRect = slider.getBoundingClientRect();
       var offset = {
-        top: sliderRect.top + document.body.scrollTop,
-        left: sliderRect.left + document.body.scrollLeft
+        top: sliderRect.top + document.body.scrollTop + document.documentElement.scrollTop,
+        left: sliderRect.left + document.body.scrollLeft + document.documentElement.scrollLeft
       };
       var width = slider.offsetHeight;
       var pageY = getPageY(input);


### PR DESCRIPTION
* IE has no support for CSS keyword `initial`;

  I removed `xxx: initial;` and set that to the initial value of the property explicitly. Though [some original code](https://github.com/NUKnightLab/juxtapose/blob/5edbd9defd86eff351efdce8dfb57b43fc07c688/juxtapose/css/juxtapose.css#L176-L179) kept both. Not sure which is preferred.

* IE and Firefox store the number of pixels the document has been scrolled in `document.documentElement.scrollTop` rather than `document.body.scrollTop`.

  This change is consistent with code [here](https://github.com/NUKnightLab/juxtapose/blob/5edbd9defd86eff351efdce8dfb57b43fc07c688/juxtapose/js/juxtapose.js#L175) and [there](https://github.com/NUKnightLab/juxtapose/blob/5edbd9defd86eff351efdce8dfb57b43fc07c688/juxtapose/js/juxtapose.js#L187):

  ```
  pageX = e.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
  ```