### PR TITLE
Use `currentColor` for easier styling

### DIFF
--- a/juxtapose/css/juxtapose.css
+++ b/juxtapose/css/juxtapose.css
@@ -9,6 +9,7 @@ div.jx-slider {
 	position: relative;
 	overflow: hidden;
 	cursor: pointer;
+	color: #f3f3f3;
 }
 
 
@@ -27,8 +28,8 @@ div.jx-arrow {
 
 div.jx-controller {
 	// box-shadow: 
-	// 	0 4px 0px 0px #f3f3f3,
-	// 	0 -4px 0px 0px #f3f3f3,
+	// 	0 4px 0px 0px currentColor,
+	// 	0 -4px 0px 0px currentColor,
 	// 	0px 0px 4px 1px rgba(0,0,0,0.3),
 	// 	0px 0px 4px 1px rgba(0,0,0,0.3);
 }
@@ -46,13 +47,13 @@ div.jx-control {
 	margin-right: auto;
 	margin-left: auto;
 	width: 3px;
-	background-color: #f3f3f3;
+	background-color: currentColor;
 }
 
 .vertical div.jx-control {
 	height: 3px;
 	width: 100%;
-	background-color: #f3f3f3;
+	background-color: currentColor;
 	position: relative;
 	top: 50%;
 	transform: translateY(-50%);
@@ -66,7 +67,7 @@ div.jx-controller {
 	height: 60px;
 	width: 9px;
 	margin-left: -3px;
-	background-color: #f3f3f3;
+	background-color: currentColor;
 }
 
 .vertical div.jx-controller {
@@ -103,14 +104,14 @@ div.jx-arrow.jx-left {
 	left: 2px;
 	border-style: solid;
 	border-width: 8px 8px 8px 0;
-	border-color: transparent #f3f3f3 transparent transparent;
+	border-color: transparent currentColor transparent transparent;
 }
 
 div.jx-arrow.jx-right {
 	right: 2px;
 	border-style: solid;
 	border-width: 8px 0 8px 8px;
-	border-color: transparent transparent transparent #f3f3f3;
+	border-color: transparent transparent transparent currentColor;
 }
 
 .vertical div.jx-arrow.jx-left {
@@ -118,7 +119,7 @@ div.jx-arrow.jx-right {
 	top: 2px;
 	border-style: solid;
 	border-width: 0px 8px 8px 8px;
-	border-color: transparent transparent #f3f3f3 transparent;
+	border-color: transparent transparent currentColor transparent;
 }
 
 .vertical div.jx-arrow.jx-right {
@@ -127,7 +128,7 @@ div.jx-arrow.jx-right {
 	bottom: 2px;
 	border-style: solid;
 	border-width: 8px 8px 0 8px;
-	border-color: #f3f3f3 transparent transparent transparent;
+	border-color: currentColor transparent transparent transparent;
 }
 
 div.jx-handle:hover div.jx-arrow.jx-left,


### PR DESCRIPTION
`currentColor` is supported by almost every browsers except IE <= 8.

http://caniuse.com/#feat=currentcolor

By using `currentColor`, to style the color of the slider, only one statement is needed:

```
div.jx-slider { color: #123456; }
```