### PR TITLE
fix: auto width in IE

### DIFF
--- a/juxtapose/css/juxtapose.css
+++ b/juxtapose/css/juxtapose.css
@@ -170,6 +170,7 @@ div.jx-image {
 
 div.jx-image img {
 	height: 100%;
+	width: auto;
 	z-index: 5;
 	position: absolute;
 	margin-bottom: 0;


### PR DESCRIPTION
IE appears to output width/height attributes on the images meaning they
become stretched. Adding width:auto prevents this