### PR TITLE
Bump gunicorn 19.3.0 -> 23.0.0 (CVE-2024-1135)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.1.1
 boto3==1.13.26
-gunicorn==19.3.0
+gunicorn==23.0.0
 requests


### PR DESCRIPTION
gunicorn 22.0.0 fixed CVE-2024-1135, an HTTP request-smuggling vulnerability in Transfer-Encoding header parsing. This app was still on 19.3.0 (released 2015). 23.0.0 is the newest release still compatible with this app's Python 3.7.17 -- 24.0.0 raised the floor to Requires-Python >=3.10.

Reviewed every year's changelog across the full 19.3.0 -> 23.0.0 span (2015-2024) for breaking changes. Nothing found applies to this app's usage: no --worker-class (plain sync workers), no gunicorn config file, no gunicorn internals imported in app code, no gunicorn_django/ django_settings usage (both removed in 2017), no gaiohttp worker (deprecated/removed). The only functionally relevant changes are the 22.0.0 HTTP-parsing strictness fixes (security-positive, doesn't affect legitimate traffic through nginx).

Verified live: installed into the real venv, restarted, confirmed "Using worker: sync" with gunicorn 23.0.0 in the startup log, and confirmed the homepage (the app's real functional surface, including static example assets) serves correctly through nginx. /examples/ and /embed/ return 500 (jinja2.TemplateNotFound) both before and after -- those templates don't exist in this checkout at all (examples content lives in _examples.html, included on the homepage), unrelated to this change.