### PR TITLE
Bump Flask 2.1.1 -> 2.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.1
+Flask==2.2.5
 boto3==1.13.26
 gunicorn==23.0.0
 requests


### PR DESCRIPTION
Newest release still compatible with this app's Python 3.7.17. Verified live: restarted the service, confirmed clean startup and the homepage serving correctly through nginx.